### PR TITLE
Update RedirectBackHelpers.cfm

### DIFF
--- a/helpers/RedirectBackHelpers.cfm
+++ b/helpers/RedirectBackHelpers.cfm
@@ -4,7 +4,7 @@ function redirectBack() {
     var moduleSettings = wirebox.getInstance( dsl = "coldbox:moduleSettings:redirectBack" );
     var flash = wirebox.getInstance( dsl = "coldbox:flash" );
     arguments.event = flash.get( moduleSettings.key, "" );
-    setNextEvent( argumentCollection = arguments );
+    relocate( argumentCollection = arguments );
 }
 
 </cfscript>


### PR DESCRIPTION
`relocate()` is the correct method to use for ColdBox 6+. `setNextEvent()` has been deprecated.